### PR TITLE
Ken script

### DIFF
--- a/scripts/checker.py
+++ b/scripts/checker.py
@@ -1,0 +1,32 @@
+import os
+import imghdr
+from PIL import Image
+import shutil
+
+supported_image_ext = ('png', 'bmp', 'jpeg')
+
+if __name__ == '__main__':
+    root_dir = "."
+    files_in_dir = os.listdir(root_dir)
+    log_file = open("unsupported_images.txt", "w+")
+
+    original_path = os.getcwd()    # user also can modify the path they want save their unsupported images, exp : "C:\\Users\\ken\\Documents"
+    directory = "UnsupportedImg"
+    path = os.path.join(original_path, directory)
+    os.mkdir(path)
+    
+    for file in files_in_dir:
+        if os.path.isfile(file):
+            image_type = imghdr.what(file)
+            if image_type is not None and image_type not in supported_image_ext:
+                log_str = "Filename: {} - Image type: {}".format(file, image_type)
+                print(log_str)
+                log_file.write(log_str + "\n")
+                im = Image.open(file).convert("RGB")
+                name = os.path.splitext(file)[0]
+                im.save("{}.jpg".format(name), "jpeg")
+                shutil.move(file, path)
+    log_file.close()
+
+    
+    

--- a/scripts/checker.py
+++ b/scripts/checker.py
@@ -10,9 +10,9 @@ if __name__ == '__main__':
     files_in_dir = os.listdir(root_dir)
     log_file = open("unsupported_images.txt", "w+")
 
-    original_path = os.getcwd()    # user also can modify the path they want save their unsupported images, exp : "C:\\Users\\ken\\Documents"
+    targeted_path = os.getcwd()    # user also can modify the path they want save their unsupported images, exp : change the os.getcwd() to "C:\\Users\\ken\\Documents"
     directory = "UnsupportedImg"
-    path = os.path.join(original_path, directory)
+    path = os.path.join(targeted_path, directory)
     os.mkdir(path)
     
     for file in files_in_dir:


### PR DESCRIPTION
**Description**
Backup script for Classifai user that encountered unsupported image format. Users need to download pillow module by running "pip install Pillow". This python script will convert the unsupported image format to jpeg format. It also moves the unsupported image to "UnsupportedImg" directory so they still keep unsupported images. Users can choose the path they want to save the directory.